### PR TITLE
feat: manage repository infrastructure locally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
       TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: opentofu/setup-opentofu@a1320f892987e89d278cc92dc5adc984fb93aca4 # v2.0.2
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -26,3 +27,6 @@ jobs:
       - run: pnpm fmt:check
       - run: pnpm test
       - run: pnpm test:integration
+
+      - run: tofu -chdir=infra/github init -backend=false
+      - run: tofu -chdir=infra/github validate

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 node_modules/
 .direnv/
+.terraform/
+*.tfstate
+*.tfstate.*
 *.tsbuildinfo
 .env
 config.jsonc

--- a/README.md
+++ b/README.md
@@ -52,6 +52,21 @@ pnpm lint
 pnpm fmt
 ```
 
+### Repository infrastructure
+
+`infra/github` manages this repository through the versioned
+`zunoser/tfmodule-gh-repo-kit` OpenTofu module. Its state remains in the shared
+R2 backend at `github/repositories/calendar/terraform.tfstate`.
+
+Static validation does not require credentials:
+
+```sh
+tofu -chdir=infra/github init -backend=false
+tofu -chdir=infra/github validate
+```
+
+A real plan additionally requires the R2 backend credentials and a GitHub token.
+
 ### パッケージ構成
 
 | パッケージ        | 役割                                                                                          |

--- a/flake.nix
+++ b/flake.nix
@@ -23,12 +23,14 @@
             mkdir -p $out/bin
             corepack enable --install-directory $out/bin
           '';
+          tofu = pkgs.opentofu.withPlugins (plugins: [ plugins.integrations_github ]);
         in
         {
           default = pkgs.mkShellNoCC {
             packages = [
               pkgs.nodejs
               corepackShims
+              tofu
             ];
           };
         }

--- a/infra/github/.terraform.lock.hcl
+++ b/infra/github/.terraform.lock.hcl
@@ -1,0 +1,37 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/integrations/github" {
+  version     = "6.13.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:2kD+4leuV8tBBXv+EPeehmfW6cDhIzVki61OXsGCtRI=",
+    "h1:99s0C+KmzXIsUJY0tKlgfcFUIuuXjCK0TAeeZ8HaOZQ=",
+    "h1:Mug81HyUTKKMngXMOtBxuQ8ge3dVnzt9tGcF9SxLcVE=",
+    "h1:RhCWa2aaFVKF/HzeR0fkIxZmoJvkGrv07hE0z09aPQs=",
+    "h1:YS8951MRtP4YNs2CNsDfqE7Mr9tDz/Y7xDSo18zyCkQ=",
+    "h1:Z0dj6yhxjLxg44gGNkh3zdAPY9iNkkiC+n7mEJcvUHY=",
+    "h1:a9VUv7chtxc+vro0uZo12PhBGbyeq3uKslrKLDHbkeg=",
+    "h1:awjLJy4zAQRONIVuKbsFSOpEWYWREdeeAXQHkhDXMDI=",
+    "h1:gz9DIUPAPQf0wI9dcmcNMgPBY/AwUfzKZbVnUMbAd9I=",
+    "h1:jPHxtaeO8mgFGGWdEmATq/BNGo1LkE6FYFgMa6Dum08=",
+    "h1:jXEm7QnQCF2UG4KTgDMwT2cEqezPE8a+3V0iA8N1r7k=",
+    "h1:jjeEBnfOJI+bV/rf1721l4B3fNO7Yws4AKf4NDdhiho=",
+    "h1:q30+GXpjFPaGQIZe7V3mG4SxKv1h8k6qp2XIfyMxyy0=",
+    "h1:y0Sujto8gttV86innNp/LTMzq7CqsFpBs7XKH8AlMl4=",
+    "zh:0ab29fc21699f34345cf0bbbe44745fd1b143b7c73b410c1dc4abe05ffad0a84",
+    "zh:1aed10d06755d420bb3a893bf548ab2932297a9d094c04c5a8501e949ca186ed",
+    "zh:2a6a11c21eae408055f45b9533c07afd2e845f6d496fd1b645aec2e873012103",
+    "zh:5dd05dee677f6ebdbed00cbb1b9be444ab2d1062d345cbc9ec50a47cb41b8622",
+    "zh:6b757d034831243d67ddda869eac4368cef539848bd97511f4d68f1aa38a9c88",
+    "zh:947c9b5b238f0364c57a705beabd24d3eea3159a6f3a24c07e3fbb13657ffae0",
+    "zh:a676549a98164b61630658cbeb6c17820331ca04a049dc9b5095996a0c31ffbe",
+    "zh:a8a81b7fe41dd61eb6a6fa5e08a4dd9ee070e862868252a7fd4cfce30364efee",
+    "zh:c26a9bca4865665084e7f59b1402d7aff34ee63a418d7401a0658fa280cad4d4",
+    "zh:c638d8d0762e62ea188f86302954ef4c92803f2160f0a45fca0cd13974bd3725",
+    "zh:e739a0b7e81ca816944a18a38e679f4015edf8be7ac319815cdea865ba7727d7",
+    "zh:ec099487ea3de8999c84b3b791e242d728461e51fe344832b37bd8d521201c77",
+    "zh:f016ff9e2daab5b88185cec0795213049d105439ffd585d3309a714514ccae13",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+  ]
+}

--- a/infra/github/backend.tf
+++ b/infra/github/backend.tf
@@ -1,0 +1,14 @@
+terraform {
+  backend "s3" {
+    bucket                      = "zunoser-tofu-state"
+    key                         = "github/repositories/calendar/terraform.tfstate"
+    region                      = "auto"
+    skip_credentials_validation = true
+    skip_region_validation      = true
+    skip_metadata_api_check     = true
+    skip_requesting_account_id  = true
+    skip_s3_checksum            = true
+    use_path_style              = true
+    use_lockfile                = true
+  }
+}

--- a/infra/github/module_gh_repo_kit.tf
+++ b/infra/github/module_gh_repo_kit.tf
@@ -1,0 +1,20 @@
+module "repository" {
+  source = "git::https://github.com/zunoser/tfmodule-gh-repo-kit.git?ref=v0.1.0"
+
+  name        = "calendar"
+  description = ""
+  visibility  = "public"
+
+  general = {
+    auto_init              = false
+    default_branch         = "main"
+    allow_merge_commit     = true
+    allow_rebase_merge     = true
+    allow_squash_merge     = true
+    delete_branch_on_merge = false
+  }
+
+  # Keep the existing repository policy unchanged. Enable the standard
+  # ruleset separately after maintainers agree on the rollout.
+  default_branch_ruleset = null
+}

--- a/infra/github/provider.tf
+++ b/infra/github/provider.tf
@@ -1,0 +1,3 @@
+provider "github" {
+  owner = "zunoser"
+}

--- a/infra/github/versions.tf
+++ b/infra/github/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- move the calendar repository OpenTofu root into `infra/github`
- keep the existing R2 state key and module/resource addresses unchanged
- add OpenTofu to the Nix dev shell and validate the root in CI

## Verification

- `tofu -chdir=infra/github init -backend=false -lockfile=readonly`
- `tofu -chdir=infra/github validate`
- actionlint
- `pnpm fmt:check`
- `pnpm typecheck`
- `pnpm test` (38 tests)
- real R2-backed plan matches the pre-move plan exactly

## Rollout

Merge this PR before removing `terraform/resources/github/repos/calendar` from `zunoser/tofu-configuration`.