### PR TITLE
fix: keep automatic branch deletion enabled

### DIFF
--- a/infra/github/module_gh_repo_kit.tf
+++ b/infra/github/module_gh_repo_kit.tf
@@ -11,7 +11,7 @@ module "repository" {
     allow_merge_commit     = true
     allow_rebase_merge     = true
     allow_squash_merge     = true
-    delete_branch_on_merge = false
+    delete_branch_on_merge = true
   }
 
   # Keep the existing repository policy unchanged. Enable the standard


### PR DESCRIPTION
## Summary

- keep `delete_branch_on_merge` enabled in the relocated repository definition
- match the current GitHub repository setting

## Verification

- `tofu -chdir=infra/github fmt -check`
- `tofu -chdir=infra/github validate`
- real R2-backed plan no longer includes a `delete_branch_on_merge` change