### PR TITLE
feat: manage repository labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ pnpm fmt
 
 `infra/github` manages this repository through the versioned
 `zunoser/tfmodule-gh-repo-kit` OpenTofu module. Its state remains in the shared
-R2 backend at `github/repositories/calendar/terraform.tfstate`.
+R2 backend at `github/repositories/calendar/terraform.tfstate`. Repository
+labels are declared alongside the module in `infra/github/labels.tf`.
 
 Static validation does not require credentials:
 

--- a/infra/github/labels.tf
+++ b/infra/github/labels.tf
@@ -1,0 +1,29 @@
+locals {
+  repository_labels = {
+    "Birthday🎂" = {
+      color       = "eff587"
+      description = ""
+    }
+    "Gambling💰" = {
+      color       = "ed9324"
+      description = ""
+    }
+    "Geek💻" = {
+      color       = "6c30bc"
+      description = ""
+    }
+    "Nerd🤓" = {
+      color       = "f74761"
+      description = ""
+    }
+  }
+}
+
+resource "github_issue_label" "this" {
+  for_each = local.repository_labels
+
+  repository  = module.repository.name
+  name        = each.key
+  color       = each.value.color
+  description = each.value.description
+}

--- a/infra/github/labels.tf
+++ b/infra/github/labels.tf
@@ -2,19 +2,19 @@ locals {
   repository_labels = {
     "Birthday🎂" = {
       color       = "eff587"
-      description = ""
+      description = "誕生日に関する予定"
     }
     "Gambling💰" = {
       color       = "ed9324"
-      description = ""
+      description = "ギャンブルに関する予定"
     }
     "Geek💻" = {
       color       = "6c30bc"
-      description = ""
+      description = "技術やコンピューターに関する予定"
     }
     "Nerd🤓" = {
       color       = "f74761"
-      description = ""
+      description = "趣味やオタク活動に関する予定"
     }
   }
 }


### PR DESCRIPTION
## Summary

- declare the four existing calendar labels in `infra/github/labels.tf`
- keep label ownership repository-local
- leave the shared module and other repository settings unchanged

## Verification

- credential-free `tofu init -backend=false -lockfile=readonly`
- `tofu validate`
- `pnpm fmt:check`

After merge, the existing labels will be imported into the current R2 state with CLI imports; no label will be recreated.