### PR TITLE
feat: resolve today's date from TZ env var

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -16,6 +16,8 @@ jobs:
   daily:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      TZ: Asia/Tokyo
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/remind.yml
+++ b/.github/workflows/remind.yml
@@ -12,6 +12,8 @@ jobs:
   remind:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      TZ: Asia/Tokyo
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/packages/cli/src/close.ts
+++ b/packages/cli/src/close.ts
@@ -2,7 +2,7 @@
 
 import { readFile } from "node:fs/promises";
 import { getGitHubCalendar, parseConfig, pastOpenEvents } from "@zunoser/calendar-core";
-import { todayInTokyo } from "@zunoser/utils";
+import { getToday } from "@zunoser/utils";
 import { defineCommand } from "citty";
 
 export const close = defineCommand({
@@ -15,7 +15,7 @@ export const close = defineCommand({
     const config = parseConfig(await readFile(args.config, "utf8"));
     const { getCalendar, closeIssue } = await getGitHubCalendar(config);
 
-    const targets = pastOpenEvents(await Array.fromAsync(getCalendar()), todayInTokyo());
+    const targets = pastOpenEvents(await Array.fromAsync(getCalendar()), getToday());
     if (targets.length === 0) {
       console.log("対象はありません");
       return;

--- a/packages/cli/src/svg-render.ts
+++ b/packages/cli/src/svg-render.ts
@@ -2,7 +2,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { filterDated, getGitHubCalendar, parseConfig, sortByStartDate } from "@zunoser/calendar-core";
 import { monthOf, nextMonth, toSvg, type SvgEvent } from "@zunoser/calendar-svg";
-import { todayInTokyo, type IsoDate } from "@zunoser/utils";
+import { getToday, type IsoDate } from "@zunoser/utils";
 import { defineCommand } from "citty";
 
 const ISO_MONTH = /^\d{4}-(0[1-9]|1[0-2])$/;
@@ -28,7 +28,7 @@ export const svgRender = defineCommand({
     output: { type: "string", required: true, alias: "o", description: "出力先のSVGパス" },
   },
   async run({ args }) {
-    const today = todayInTokyo();
+    const today = getToday();
     const month = resolveMonth(args.month, today);
     const config = parseConfig(await readFile(args.config, "utf8"));
     const { getCalendar } = await getGitHubCalendar(config);

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+const envSchema = z.object({
+  TZ: z.string().min(1).default("UTC"),
+});
+
+/** process.env を検証して返す */
+export const getEnv = () => envSchema.parse(process.env);

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,3 +1,3 @@
 export { isoDate, IsoDateSchema } from "./iso-date";
 export type { IsoDate } from "./iso-date";
-export { todayInTokyo } from "./today";
+export { getToday } from "./today";

--- a/packages/utils/src/today.ts
+++ b/packages/utils/src/today.ts
@@ -1,7 +1,5 @@
-// 実行時点の「今日」。カレンダーの基準日は日本時間で決める。
-
+import { getEnv } from "./env";
 import { isoDate } from "./iso-date";
 
-/** 日本時間での今日の暦日を返す */
-export const todayInTokyo = () =>
-  isoDate(new Intl.DateTimeFormat("en-CA", { timeZone: "Asia/Tokyo" }).format(new Date()));
+/** 今日の暦日を返す */
+export const getToday = () => isoDate(new Intl.DateTimeFormat("en-CA", { timeZone: getEnv().TZ }).format(new Date()));

--- a/packages/utils/test/env.test.ts
+++ b/packages/utils/test/env.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getEnv } from "../src/env";
+
+describe("getEnv", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("TZ 未設定なら UTC になる", () => {
+    vi.stubEnv("TZ", undefined);
+    expect(getEnv().TZ).toBe("UTC");
+  });
+
+  it("TZ が設定されていればその値を返す", () => {
+    vi.stubEnv("TZ", "Asia/Tokyo");
+    expect(getEnv().TZ).toBe("Asia/Tokyo");
+  });
+
+  it("TZ が空文字なら例外を投げる", () => {
+    vi.stubEnv("TZ", "");
+    expect(() => getEnv()).toThrow();
+  });
+});

--- a/packages/utils/test/today.test.ts
+++ b/packages/utils/test/today.test.ts
@@ -1,20 +1,30 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { todayInTokyo } from "../src/today";
+import { getToday } from "../src/today";
 
-describe("todayInTokyo", () => {
+describe("getToday", () => {
   afterEach(() => {
+    vi.unstubAllEnvs();
     vi.useRealTimers();
   });
 
   it("UTC では前日でも JST で日付が変わっていれば翌日になる", () => {
+    vi.stubEnv("TZ", "Asia/Tokyo");
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-08-20T15:30:00Z")); // JST 2026-08-21 00:30
-    expect(todayInTokyo()).toBe("2026-08-21");
+    expect(getToday()).toBe("2026-08-21");
   });
 
   it("JST で日付が変わる前は同日のまま", () => {
+    vi.stubEnv("TZ", "Asia/Tokyo");
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-08-20T14:59:00Z")); // JST 2026-08-20 23:59
-    expect(todayInTokyo()).toBe("2026-08-20");
+    expect(getToday()).toBe("2026-08-20");
+  });
+
+  it("TZ 未設定なら UTC で決める", () => {
+    vi.stubEnv("TZ", undefined);
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-20T15:30:00Z"));
+    expect(getToday()).toBe("2026-08-20");
   });
 });


### PR DESCRIPTION
## 概要

`todayInTokyo` にハードコードされていた `Asia/Tokyo` をやめ、環境変数 `TZ` を zod で検証して使うようにする。

- `packages/utils/src/env.ts` を新設。well-known な環境変数を `envSchema` で検証して読む `getEnv()` を追加 (`TZ` は未設定なら `UTC`、空文字は ZodError)
- `todayInTokyo` → `getToday` にリネーム。基準日は `TZ` のタイムゾーンで決まる
- CI (`daily.yml` / `remind.yml`) にジョブレベルで `env: TZ: Asia/Tokyo` を明示し、カレンダーの基準日は従来どおり JST を維持
- テスト: `env.test.ts` 新設 (既定値 / 上書き / 空文字)、`today.test.ts` は `vi.stubEnv` で TZ を明示

## 動作への影響

CI では `TZ: Asia/Tokyo` を指定しているため従来と同じ挙動。`TZ` 未設定のローカル実行のみ UTC 基準になる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)